### PR TITLE
Fix: #74 Context Menu Field Item hides Tab Children component

### DIFF
--- a/src/ADempiere/modules/window/WindowType/DomainType.ts
+++ b/src/ADempiere/modules/window/WindowType/DomainType.ts
@@ -97,6 +97,16 @@ export enum EventType {
     STATE_CHANGED = 2
 }
 
+export interface IChangeLogData {
+    columnName: string
+    displayColumnName: string
+    oldValue: string
+    newValue: string
+    oldDisplayValue: string
+    newDisplayValue: string
+    description: string
+}
+
 export interface IEntityLogData {
     logId: number
     id: number
@@ -109,17 +119,12 @@ export interface IEntityLogData {
     eventType: EntityEventType
     eventTypeName: string
     logDate: number
-    changeLogsList: IEntityLogData
+    changeLogsList: IChangeLogData[]
 }
 
-export interface IChangeLogData {
+export interface IEntityLogDataExtended extends IEntityLogData {
     columnName: string
-    displayColumnName: string
-    oldValue: string
-    newValue: string
-    oldDisplayValue: string
-    newDisplayValue: string
-    description: string
+    type: string
 }
 
 export interface IEntityChatData {

--- a/src/ADempiere/modules/window/components/ContainerInfo/RecordLogs/template.vue
+++ b/src/ADempiere/modules/window/components/ContainerInfo/RecordLogs/template.vue
@@ -7,11 +7,11 @@
       <el-scrollbar :wrap-class="classIsMobilePanel">
         <el-timeline>
           <el-timeline-item
-            v-for="(listLogs, key) in gettersListRecordLogs"
-            :key="key"
+            v-for="(listLogs, key) in gettersListRecordLogs.sort(sortSequence)"
+            :key="listLogs.logId"
+            :type="listLogs.type"
             :timestamp="translateDate(listLogs.logDate)"
             placement="top"
-            color="#008fd3"
           >
             <el-card shadow="hover" class="clearfix">
               <div>
@@ -71,6 +71,6 @@
     height: 57vh;
   }
   .panel {
-    height: 100vh;
+    height: 75vh;
   }
 </style>

--- a/src/ADempiere/modules/window/store/ContainerInfo/actions.ts
+++ b/src/ADempiere/modules/window/store/ContainerInfo/actions.ts
@@ -3,6 +3,7 @@ import { IResponseList } from '@/ADempiere/shared/utils/types'
 import { ActionContext, ActionTree } from 'vuex'
 import { requestListEntityLogs, requestListWorkflows, requestListWorkflowsLogs } from '../../WindowService'
 import { ContainerInfoState, IListEntityLogsResponse, IListWorkflowsResponse, IWorkflowProcessData } from '../../WindowType'
+import { isEmptyValue } from '@/ADempiere/shared/utils/valueUtils'
 
 type ContainerInfoActionContext = ActionContext<ContainerInfoState, IRootState>
 type ContainerInfoActionTree = ActionTree<ContainerInfoState, IRootState>
@@ -18,6 +19,9 @@ export const actions: ContainerInfoActionTree = {
     } = payload
     const pageSize = 0
     const pageToken = '0'
+    if (isEmptyValue(tableName) && (isEmptyValue(recordId) || isEmptyValue(recordUuid))) {
+      return
+    }
     return requestListEntityLogs({
       tableName,
       recordId,

--- a/src/ADempiere/modules/window/views/Window/index.ts
+++ b/src/ADempiere/modules/window/views/Window/index.ts
@@ -91,6 +91,9 @@ export default class WindowView extends Vue {
         case this.$t('field.preference'):
           component = () => import('@/ADempiere/shared/components/Field/ContextMenuField/Preference')
           break
+        case this.$t('field.logsField'):
+          component = () => import('@/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs')
+          break
       }
       return component
     }
@@ -441,6 +444,13 @@ export default class WindowView extends Vue {
 
     @Watch('getRecord')
     handleGetRecordChange(value: any) {
+      if (value && this.getTableName && this.recordId && isEmptyValue(this.gettersListRecordLogs)) {
+        this.$store.dispatch(Namespaces.ContainerInfo + '/' + 'listRecordLogs', {
+          tableName: this.getTableName,
+          recordId: this.recordId,
+          recordUuid: value.UUID
+        })
+      }
       if (!isEmptyValue(this.windowMetadata.currentTab?.tableName) && !isEmptyValue(value) && (!isEmptyValue(this.$route.query) && this.$route.query.typeAction === ActionContextName.RecordAccess)) {
         this.$store.commit(Namespaces.ContextMenu + '/' + 'setRecordAccess', true)
       }
@@ -657,11 +667,27 @@ export default class WindowView extends Vue {
     }
 
     handleChangeShowedTabChildren(isShowedChilds: any): void {
+      console.log('click button')
+      console.log(isShowedChilds)
+      console.log('data to send')
+      console.log({
+        parentUuid: this.windowUuid, // act as parentUuid
+        window: this.windowMetadata,
+        attributeName: 'isShowedTabsChildren',
+        attributeValue: isShowedChilds
+      })
+      console.warn({
+        isShowedTabsChildren: this.isShowedTabsChildren
+      })
+
       this.$store.dispatch(Namespaces.WindowDefinition + '/' + 'changeWindowAttribute', {
         parentUuid: this.windowUuid, // act as parentUuid
         window: this.windowMetadata,
         attributeName: 'isShowedTabsChildren',
         attributeValue: isShowedChilds
+      })
+      console.warn({
+        isShowedTabsChildren2: this.isShowedTabsChildren
       })
     }
 }

--- a/src/ADempiere/shared/components/Field/ContextMenuField/Calculator/index.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/Calculator/index.ts
@@ -1,18 +1,19 @@
 import { ID, INTEGER } from '@/ADempiere/shared/utils/references'
 import { IKeyValueObject, Namespaces } from '@/ADempiere/shared/utils/types'
 import { calculationValue, clearVariables, isEmptyValue } from '@/ADempiere/shared/utils/valueUtils'
-import { Component, Prop, Ref, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Ref, Watch } from 'vue-property-decorator'
 import { ICalculatorObject } from './type'
 
 import buttons from './buttons'
 import Template from './template.vue'
 import { PanelContextType } from '@/ADempiere/shared/utils/DictionaryUtils/ContextMenuType'
+import MixinContextMenuField from '../MixinContextMenuField'
 
 @Component({
   name: 'FieldCalc',
   mixins: [Template]
 })
-export default class FieldCalc extends Vue {
+export default class FieldCalc extends Mixins(MixinContextMenuField) {
     @Prop({ type: Object, required: true }) fieldAttributes!: any
     @Ref() readonly calculatorInput!: HTMLElement
     @Prop({ type: Number, default: undefined }) fieldValue?: number

--- a/src/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs/index.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs/index.ts
@@ -5,14 +5,15 @@ import {
 } from '@/ADempiere/modules/window'
 import { Namespaces } from '@/ADempiere/shared/utils/types'
 import { isEmptyValue } from '@/ADempiere/shared/utils/valueUtils'
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import MixinContextMenuField from '../MixinContextMenuField'
 import Template from './template.vue'
 
 @Component({
   name: 'FieldChangeLogs',
   mixins: [Template]
 })
-export default class FieldChangeLogs extends Vue {
+export default class FieldChangeLogs extends Mixins(MixinContextMenuField) {
   @Prop({
     type: Object,
     required: true

--- a/src/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs/index.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs/index.ts
@@ -1,0 +1,105 @@
+import { DeviceType } from '@/ADempiere/modules/app/AppType'
+import {
+  IEntityLogData,
+  IEntityLogDataExtended
+} from '@/ADempiere/modules/window'
+import { Namespaces } from '@/ADempiere/shared/utils/types'
+import { isEmptyValue } from '@/ADempiere/shared/utils/valueUtils'
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import Template from './template.vue'
+
+@Component({
+  name: 'FieldChangeLogs',
+  mixins: [Template]
+})
+export default class FieldChangeLogs extends Vue {
+  @Prop({
+    type: Object,
+    required: true
+  })
+  fieldAttributes!: any
+
+  @Prop({
+    type: String,
+    default: undefined
+  })
+  recordUuid?: string
+
+  // Data
+  private isLoading = false
+  private currentKey = 0
+  private typeAction = 0
+
+  // Computed properties
+  get language(): string {
+    return this.$store.getters.language as string
+  }
+
+  get listLogsField(): IEntityLogDataExtended[] {
+    const log: IEntityLogData[] = this.$store.getters[
+      Namespaces.ContainerInfo + '/' + 'getRecordLogs'
+    ].entityLogs as IEntityLogData[]
+    if (log) {
+      const logsField = log.map(element => {
+        let type
+        if (
+          !isEmptyValue(element.changeLogsList[0].newDisplayValue) &&
+          isEmptyValue(element.changeLogsList[0].oldDisplayValue)
+        ) {
+          type = 'success'
+        } else if (
+          isEmptyValue(element.changeLogsList[0].newDisplayValue) &&
+          !isEmptyValue(element.changeLogsList[0].oldDisplayValue)
+        ) {
+          type = 'danger'
+        } else {
+          type = 'primary'
+        }
+        return {
+          ...element,
+          columnName: element.changeLogsList[0].columnName,
+          type
+        }
+      })
+      return logsField.filter(
+        field => field.columnName === this.fieldAttributes.columnName
+      )
+    }
+    return []
+  }
+
+  get isMobile(): boolean {
+    return (this.$store.state.app.device as DeviceType) === DeviceType.Mobile
+  }
+
+  get classIsMobilePanel(): string {
+    if (this.isMobile) {
+      return 'panel-mobile'
+    }
+    return 'scroll-child'
+  }
+
+  //  Methods
+  sortSequence(
+    itemA: IEntityLogDataExtended,
+    itemB: IEntityLogDataExtended
+  ): number {
+    return (
+      new Date().setTime(new Date(itemB.logDate).getTime()) -
+      new Date().setTime(new Date(itemA.logDate).getTime())
+    )
+  }
+
+  translateDate(value: string | number | Date): string {
+    return this.$d(new Date(value), 'long', this.language)
+  }
+
+  showkey(key: number, index: number) {
+    if (key === this.currentKey && index === this.typeAction) {
+      this.currentKey = 1000
+    } else {
+      this.currentKey = key
+      this.typeAction = index
+    }
+  }
+}

--- a/src/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs/template.vue
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs/template.vue
@@ -1,0 +1,83 @@
+<template>
+  <el-card class="box-card">
+    <div slot="header" class="clearfix">
+      <span>
+        {{ $t('field.logsField') }}
+        <b> {{ fieldAttributes.name }} </b>
+      </span>
+    </div>
+    <div>
+      <el-scrollbar v-if="!isEmptyValue(listLogsField)" :wrap-class="classIsMobilePanel">
+        <el-timeline>
+          <el-timeline-item
+            v-for="(listLogs) in listLogsField.sort(sortSequence)"
+            :key="listLogs.logId"
+            :type="listLogs.type"
+            :timestamp="translateDate(listLogs.logDate)"
+            placement="top"
+          >
+            <el-card shadow="hover" class="clearfix">
+              <div>
+                {{ listLogs.userName }}
+              </div>
+              <!-- <el-collapse-transition> -->
+              <div>
+                <span v-for="(list, index) in listLogs.changeLogsList" :key="index">
+                  <p v-if="list.columnName === 'DocStatus'">
+                    <b> {{ list.displayColumnName }} :</b>
+                    <strike>
+                      <el-tag :type="tagStatus(list.oldValue)">
+                        {{ list.oldDisplayValue }}
+                      </el-tag>
+                    </strike>
+                    <el-tag :type="tagStatus(list.newValue)">
+                      {{ list.newDisplayValue }}
+                    </el-tag>
+                  </p>
+                  <p v-else>
+                    <b> {{ list.displayColumnName }} :</b>
+                    <strike>
+                      <el-link type="danger">
+                        {{ list.oldDisplayValue }}
+                      </el-link>
+                    </strike>
+                    <el-link type="success">
+                      {{ list.newDisplayValue }}
+                    </el-link>
+                  </p>
+                </span>
+              </div>
+              <!-- </el-collapse-transition> -->
+            </el-card>
+          </el-timeline-item>
+        </el-timeline>
+      </el-scrollbar>
+    </div>
+  </el-card>
+</template>
+
+<style lang="scss" scoped>
+  .custom-tittle-popover {
+    font-size: 14px;
+    font-weight: bold;
+  }
+</style>
+<style lang="scss">
+  /**
+   * Separation between elements (item) of the form
+   */
+  .el-form-item {
+    margin-bottom: 10px !important;
+    margin-left: 10px;
+    margin-right: 10px;
+  }
+  /**
+   * Reduce the spacing between the form element and its label
+   */
+  .el-form--label-top .el-form-item__label {
+    padding-bottom: 0px !important;
+  }
+  .panel-mobile {
+    height: 80vh;
+  }
+</style>

--- a/src/ADempiere/shared/components/Field/ContextMenuField/ContextInfo/index.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/ContextInfo/index.ts
@@ -1,14 +1,15 @@
 import { Namespaces } from '@/ADempiere/shared/utils/types'
 import { isEmptyValue, recursiveTreeSearch } from '@/ADempiere/shared/utils/valueUtils'
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { RouteConfig } from 'vue-router'
+import MixinContextMenuField from '../MixinContextMenuField'
 import Template from './template.vue'
 
 @Component({
   name: 'FieldContextInfo',
   mixins: [Template]
 })
-export default class FieldContextInfo extends Vue {
+export default class FieldContextInfo extends Mixins(MixinContextMenuField) {
     @Prop({ type: Object, required: true }) fieldAttributes!: any
     @Prop({ type: [Number, String, Boolean, Array, Object, Date], default: undefined }) fieldValue?: [Number, String, Boolean, any[], Object, Date]
     // eslint-disable-next-line

--- a/src/ADempiere/shared/components/Field/ContextMenuField/MixinContextMenuField.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/MixinContextMenuField.ts
@@ -1,0 +1,21 @@
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+
+@Component({
+  name: 'MixinContextMenuField'
+})
+export default class MixinContextMenuField extends Vue {
+    @Prop({ type: Boolean, default: false }) visible?: boolean
+
+    @Watch('visible')
+    handleVisibleChange(newValue: boolean, oldValue: boolean) {
+      if (newValue === false && oldValue === true) {
+        this.$router.push({
+          name: this.$route.name!,
+          query: {
+            ...this.$route.query,
+            typeAction: ''
+          }
+        }).catch(() => {})
+      }
+    }
+}

--- a/src/ADempiere/shared/components/Field/ContextMenuField/Preference/index.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/Preference/index.ts
@@ -1,6 +1,6 @@
 import preferenceFields from './preferenceFields'
 import { setPreference, deletePreference } from '@/ADempiere/modules/field/FieldService/preference'
-import { createFieldFromDictionary, IFieldTemplateData } from '@/ADempiere/shared/utils/lookupFactory'
+import { IFieldTemplateData } from '@/ADempiere/shared/utils/lookupFactory'
 import { Component, Prop, Watch, Mixins } from 'vue-property-decorator'
 import { IFieldLocation } from '../../FieldLocation/fieldList'
 import language from '@/lang'
@@ -9,6 +9,7 @@ import Template from './template.vue'
 import MixinForm from '../../../Form/MixinForm'
 import { isEmptyValue } from '@/ADempiere/shared/utils/valueUtils'
 import { Namespaces } from '@/ADempiere/shared/utils/types'
+import MixinContextMenuField from '../MixinContextMenuField'
 
 type IPreferenceMetadataItem = IFieldTemplateData & { containerUuid?: string }
 
@@ -16,7 +17,7 @@ type IPreferenceMetadataItem = IFieldTemplateData & { containerUuid?: string }
   name: 'Preference',
   mixins: [Template, MixinForm]
 })
-export default class Preference extends Mixins(MixinForm) {
+export default class Preference extends Mixins(MixinForm, MixinContextMenuField) {
     @Prop({
       type: [Object],
       required: true,

--- a/src/ADempiere/shared/components/Field/ContextMenuField/Translated/index.ts
+++ b/src/ADempiere/shared/components/Field/ContextMenuField/Translated/index.ts
@@ -1,14 +1,15 @@
 import Template from './template.vue'
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { IKeyValueObject, Namespaces } from '@/ADempiere/shared/utils/types'
 import { ILanguageData, IValueData } from '@/ADempiere/modules/core'
 import { getLocale } from '@/ADempiere/shared/lang/index'
+import MixinContextMenuField from '../MixinContextMenuField'
 
 @Component({
   name: 'FieldTranslated',
   mixins: [Template]
 })
-export default class FieldTranslated extends Vue {
+export default class FieldTranslated extends Mixins(MixinContextMenuField) {
     @Prop({ type: Object, required: true }) fieldAttributes!: any
     @Prop({ type: String, default: undefined }) recordUuid?: string
     public langValue?: string = ''

--- a/src/ADempiere/shared/components/Field/index.ts
+++ b/src/ADempiere/shared/components/Field/index.ts
@@ -44,6 +44,7 @@ export default class FieldDefinition extends Vue {
     public showPopoverPath = false
     public timeOut?: NodeJS.Timeout
     public optionColumnName?: string
+    public visibleFields: boolean[] = []
 
     // Computed properties
     get labelStyle() {
@@ -585,6 +586,9 @@ export default class FieldDefinition extends Vue {
 
     // Hooks
     created() {
+      this.listOption.map(() => {
+        this.visibleFields.push(false)
+      })
       this.optionColumnName = this.$route.query.fieldColumnName as string
       this.timeOut = setTimeout(() => {
         this.showPopoverPath = true

--- a/src/ADempiere/shared/components/Field/index.ts
+++ b/src/ADempiere/shared/components/Field/index.ts
@@ -84,6 +84,9 @@ export default class FieldDefinition extends Vue {
         case this.$t('field.preference'):
           component = () => import('@/ADempiere/shared/components/Field/ContextMenuField/Preference')
           break
+        case this.$t('field.logsField'):
+          component = () => import('@/ADempiere/shared/components/Field/ContextMenuField/ChangeLogs')
+          break
       }
       return component
     }
@@ -390,18 +393,21 @@ export default class FieldDefinition extends Vue {
           name: this.$t('field.info'),
           enabled: true,
           fieldAttributes: this.fieldAttributes,
+          svg: false,
           icon: 'el-icon-info'
         },
         {
           name: this.$t('table.ProcessActivity.zoomIn'),
           enabled: this.isContextInfo,
           fieldAttributes: this.fieldAttributes,
+          svg: false,
           icon: 'el-icon-files'
         },
         {
           name: this.$t('language'),
           enabled: this.field.isTranslatedField,
           fieldAttributes: this.fieldAttributes,
+          svg: true,
           icon: 'language'
         },
         {
@@ -410,6 +416,7 @@ export default class FieldDefinition extends Vue {
           fieldAttributes: this.fieldAttributes,
           recordDataFields: this.recordDataFields,
           valueField: this.valueField,
+          svg: false,
           icon: 'el-icon-s-operation'
         },
         {
@@ -417,7 +424,16 @@ export default class FieldDefinition extends Vue {
           enabled: true,
           fieldAttributes: this.fieldAttributes,
           valueField: this.valueField,
+          svg: false,
           icon: 'el-icon-notebook-2'
+        },
+        {
+          name: this.$t('field.logsField'),
+          enabled: true,
+          fieldAttributes: this.fieldAttributes,
+          valueField: this.valueField,
+          svg: true,
+          icon: 'tree-table'
         }
       ]
     }

--- a/src/ADempiere/shared/components/Field/template.vue
+++ b/src/ADempiere/shared/components/Field/template.vue
@@ -57,11 +57,11 @@
                     />
                     <el-button slot="reference" type="text" style="color: #606266;">
                       <div class="contents">
-                        <div v-if="option.name !== $t('language')" style="margin-right: 5%;padding-top: 3%;">
+                        <div v-if="!option.svg" style="margin-right: 5%;padding-top: 3%;">
                           <i :class="option.icon" style="font-weight: bolder;" />
                         </div>
                         <div v-else style="margin-right: 5%">
-                          <svg-icon :icon-class="option.icon" style="margin-right: 5px;" />
+                          <svg-icon :name="option.icon" :icon-class="option.icon" style="margin-right: 5px;" />
                         </div>
                         <div>
                           <span class="contents">
@@ -74,11 +74,11 @@
                     </el-button>
                   </el-popover>
                   <div v-if="isMobile" class="contents">
-                    <div v-if="option.name !== $t('language')" style="margin-right: 5%;padding-top: 3%;">
+                    <div v-if="!option.svg" style="margin-right: 5%;padding-top: 3%;">
                       <i :class="option.icon" style="font-weight: bolder;" />
                     </div>
                     <div v-else style="margin-right: 5%">
-                      <svg-icon :icon-class="option.icon" style="margin-right: 5px;" />
+                      <svg-icon :name="option.icon" :icon-class="option.icon" style="margin-right: 5px;" />
                     </div>
                     <div>
                       <span class="contents">
@@ -125,10 +125,10 @@
                   />
                   <el-button slot="reference" type="text" style="color: #606266;">
                     <div class="contents">
-                      <div v-if="option.name !== $t('language')" style="margin-right: 5%;padding-top: 3%;">
+                      <div v-if="!option.svg" style="margin-right: 5%;padding-top: 3%;">
                         <i :class="option.icon" style="font-weight: bolder;" />
                       </div>
-                      <div v-else style="margin-right: 5%; padding-left: 8%;">
+                      <div v-else style="margin-right: 5%; padding-left: 2%;">
                         <svg-icon :name="option.icon" :icon-class="option.icon" style="margin-right: 5px;" />
                       </div>
                       <div>
@@ -142,11 +142,11 @@
                   </el-button>
                 </el-popover>
                 <div v-if="false" class="contents">
-                  <div v-if="option.name !== $t('language')" style="margin-right: 5%;padding-top: 3%;">
+                  <div v-if="!option.svg" style="margin-right: 5%;padding-top: 3%;">
                     <i :class="option.icon" style="font-weight: bolder;" />
                   </div>
                   <div v-else style="margin-right: 5%">
-                    <svg-icon :icon-class="option.icon" style="margin-right: 5px;" />
+                    <svg-icon :name="option.icon" :icon-class="option.icon" style="margin-right: 5px;" />
                   </div>
                   <div>
                     <span class="contents">

--- a/src/ADempiere/shared/components/Field/template.vue
+++ b/src/ADempiere/shared/components/Field/template.vue
@@ -115,6 +115,7 @@
                   trigger="click"
                   style="padding: 0px;"
                   :hide="visibleForDesktop"
+                  v-model="visibleFields[key]"
                 >
                   <component
                     :is="optionFieldFComponentRender"
@@ -122,6 +123,7 @@
                     :field-attributes="contextMenuField.fieldAttributes"
                     :source-field="contextMenuField.fieldAttributes"
                     :field-value="contextMenuField.valueField"
+                    :visible="visibleFields[key]"
                   />
                   <el-button slot="reference" type="text" style="color: #606266;">
                     <div class="contents">

--- a/src/ADempiere/shared/components/Field/type.ts
+++ b/src/ADempiere/shared/components/Field/type.ts
@@ -6,5 +6,6 @@ export interface IOptionField {
   fieldAttributes: any
   icon: string
   recordDataFields?: any
+  svg?: boolean
   valueField?: any
 }

--- a/src/ADempiere/shared/lang/en.ts
+++ b/src/ADempiere/shared/lang/en.ts
@@ -324,6 +324,9 @@ export default {
     info: 'Information',
     calculator: 'Calculator',
     preference: 'Preference',
+    logsField: 'Field Change Log',
+    logsFieldEmpty: 'The field is still unchanged',
+    contextInfo: 'Context Info',
     codeTranslation: 'Translation Of',
     container: {
       help: 'Help',

--- a/src/ADempiere/shared/lang/es.ts
+++ b/src/ADempiere/shared/lang/es.ts
@@ -300,6 +300,9 @@ export default {
     calculator: 'Calculadora',
     preference: 'Preferencia',
     codeTranslation: 'Traduccion de ',
+    logsField: 'Bitácora de Cambios',
+    contextInfo: 'Información del Contexto',
+    logsFieldEmpty: 'El campo no tiene cambios aún',
     container: {
       help: 'Ayuda',
       description: 'Descripción'


### PR DESCRIPTION
The problem was solved by delete typeAction content from the route when the current Context Menu Field Item component is hidden.

